### PR TITLE
Listener Owners

### DIFF
--- a/include/flashbackclient/listener.h
+++ b/include/flashbackclient/listener.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <flashbackclient/defs.h>
+#include <flashbackclient/target.h>
 
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -22,8 +24,9 @@ namespace FlashBackClient
 
     struct ListenerInfo
     {
-        std::filesystem::path                              Path;
         std::chrono::time_point<std::chrono::system_clock> LastUpdate;
+        std::shared_ptr<Target>                            Owner = nullptr;
+        std::filesystem::path                              Path;
         StatusEnum Status = StatusEnum::inactive;
     };
 
@@ -36,8 +39,7 @@ namespace FlashBackClient
         virtual bool Initialize() = 0;
         virtual bool Shutdown()   = 0;
 
-        virtual bool AddListener(const std::filesystem::path& path,
-                                 int                          depth = 0) = 0;
+        virtual bool AddListener(ListenerInfo& info, int depth = 0) = 0;
 
         const std::vector<ListenerInfo>& GetListeners() const
         {

--- a/include/flashbackclient/scheduler.h
+++ b/include/flashbackclient/scheduler.h
@@ -34,7 +34,7 @@ namespace FlashBackClient
         void schedulerThread();
 
         // cppcheck-suppress unusedStructMember
-        std::vector<std::unique_ptr<Target>> _targets;
+        std::vector<std::shared_ptr<Target>> _targets;
         std::mutex                           _targetsMutex;
 
         std::atomic<bool>       _running;

--- a/include/flashbackclient/target.h
+++ b/include/flashbackclient/target.h
@@ -5,17 +5,36 @@
 
 #include <flashbackclient/trigger.h>
 
+#include <memory>
 #include <vector>
 
 namespace FlashBackClient
 {
-    class Target : public RuleManager, public SettingManager
+    class Target :
+        public RuleManager,
+        public SettingManager,
+        public std::enable_shared_from_this<Target>
     {
+    private:
+        struct Private
+        {
+            explicit Private() = default;
+        };
+
     public:
-        explicit Target(const std::filesystem::path& path) :
-            RuleManager(path), SettingManager(path) {}
+        explicit Target(const std::filesystem::path& path, Private) :
+            RuleManager(path), SettingManager(path)
+        {
+        }
 
         virtual ~Target() = default;
+
+        template<typename... Args>
+        static std::shared_ptr<Target> Create(Args&&... args)
+        {
+            return std::make_shared<Target>(std::forward<Args>(args)...,
+                                            Private());
+        }
 
         bool Initialize() override;
 
@@ -23,16 +42,19 @@ namespace FlashBackClient
 
     private:
         void afterCheck(const std::vector<Triggers>& givenTriggers = {});
+
         std::unordered_map<Rule, bool> checkOverrideRules();
         bool checkRule(Rule defaultRule, const std::vector<int>& overrideRules);
 
-        bool checkConditions(const Rule& rule, const std::vector<Triggers>& givenTriggers = {});
+        bool checkConditions(const Rule&                  rule,
+                             const std::vector<Triggers>& givenTriggers = {});
 
-        bool checkTrigger(Triggers trigger, const std::vector<Triggers>& givenTriggers = {});
+        bool checkTrigger(Triggers                     trigger,
+                          const std::vector<Triggers>& givenTriggers = {});
 
         bool checkFileChanges(const Condition& condition);
 
         bool upload();
         bool download();
     };
-} //namespace FlashBackClient
+} // namespace FlashBackClient

--- a/src/configs.cpp
+++ b/src/configs.cpp
@@ -1,16 +1,11 @@
 #include <flashbackclient/configs.h>
 
-#include <filesystem>
-
 namespace FlashBackClient
 {
-    bool ConfigManager::Initialize()
-    {
-        return SettingManager::Initialize();
-    }
+    bool ConfigManager::Initialize() { return SettingManager::Initialize(); }
 
     void ConfigManager::GenerateConfigs()
     {
         // TODO
     }
-} //namespace FlashBackClient
+} // namespace FlashBackClient

--- a/src/listener/inotify/inotify_listener.h
+++ b/src/listener/inotify/inotify_listener.h
@@ -24,8 +24,7 @@ namespace FlashBackClient
         bool Initialize() override;
         bool Shutdown() override;
 
-        bool AddListener(const std::filesystem::path& path,
-                         int                          depth = 0) override;
+        bool AddListener(ListenerInfo& info, int depth = 0) override;
 
     private:
         void listenerThread() override;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -2,6 +2,7 @@
 
 #include <flashbackclient/defs.h>
 
+#include <memory>
 #include <mutex>
 #include <yaml-cpp/yaml.h>
 
@@ -78,8 +79,7 @@ namespace FlashBackClient
                 continue;
             else
             {
-                std::unique_ptr<Target> target =
-                    std::make_unique<Target>(Target(entry.path()));
+                std::shared_ptr<Target> target = Target::Create(entry.path());
 
                 if (!target->Initialize()) continue;
                 _targets.push_back(std::move(target));

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -29,8 +29,12 @@ namespace FlashBackClient
             {
                 if (condition.TriggerName == Triggers::on_file_change)
                 {
+                    ListenerInfo info;
+                    info.Owner = shared_from_this();
+                    info.Path  = GetSettingValue<std::string>("path");
+
                     if (!ServiceLocator::Get<PlatformListener>()->AddListener(
-                            GetSettingValue<std::string>("path")))
+                            info))
                         return false;
                     return true;
                 }


### PR DESCRIPTION
Add a shared pointer to a target in the `ListenerInfo` struct to allow the listener thread to directly call `CheckRules()` on an updated target