### PR TITLE
Fix license notices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,20 @@
 ###
 ### @copyright Copyright (c) 2025 Luke Houston
 ###
-### This program is free software: you can redistribute it and/or modify
+### This file is part of FlashBackClient
+###
+### FlashBackClient is free software: you can redistribute it and/or modify
 ### it under the terms of the GNU General Public License as published by
 ### the Free Software Foundation, either version 3 of the License, or
 ### (at your option) any later version.
 ###
-### This program is distributed in the hope that it will be useful,
+### FlashBackClient is distributed in the hope that it will be useful,
 ### but WITHOUT ANY WARRANTY; without even the implied warranty of
 ### MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ### GNU General Public License for more details.
 ###
 ### You should have received a copy of the GNU General Public License
-### along with this program.  If not, see <https://www.gnu.org/licenses/>.
+### along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
 
 cmake_minimum_required(VERSION 3.12)
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,4 +27,5 @@
 
 ## Low Priority
 - [ ] Remove cppcheck-suppress comments
-- [ ] Add `show w` and `show c` commands from GPLv3 license
+- [ ] Improve command line argument documentation
+- [x] Add `show w` and `show c` commands from GPLv3 license

--- a/include/flashbackclient/condition.h
+++ b/include/flashbackclient/condition.h
@@ -14,18 +14,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/configdefs.h
+++ b/include/flashbackclient/configdefs.h
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #define DEFAULT_GLOBAL_CONFIG \

--- a/include/flashbackclient/configs.h
+++ b/include/flashbackclient/configs.h
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/defs.h
+++ b/include/flashbackclient/defs.h
@@ -7,18 +7,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/helper.h
+++ b/include/flashbackclient/helper.h
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 namespace FlashBackClient

--- a/include/flashbackclient/helper.h
+++ b/include/flashbackclient/helper.h
@@ -2,7 +2,7 @@
  * @file helper.h
  * @author Luke Houston (Romket or RomketBoi) (lukehouston08@gmail.com)
  * @brief Miscellaneous helper functions
- * @version 0.1
+ * @version 0.2
  * @date 2025-04-01
  *
  * @see helper.cpp
@@ -28,9 +28,17 @@
 
 namespace FlashBackClient
 {
+    enum class ArgsResult
+    {
+        cont,
+        err,
+        exit
+    };
+
     class Helper
     {
     public:
-        static bool ProcessCommandLineArgs(int argc, char** argv);
+        static void       DisplayNotice();
+        static ArgsResult ProcessCommandLineArgs(int argc, char** argv);
     };
 } // namespace FlashBackClient

--- a/include/flashbackclient/license_info.h
+++ b/include/flashbackclient/license_info.h
@@ -2,7 +2,7 @@
  * @file license_info.h
  * @author Luke Houston (Romket or RomketBoi) (lukehouston08@gmail.com)
  * @brief Defines various license notices to display in terminal mode
- * @version 0.1
+ * @version 0.2
  * @date 2025-04-02
  *
  * @see helper.cpp
@@ -29,7 +29,8 @@
 #pragma once
 
 #define NOTICE \
-    R"(  FlashBackClient  Copyright (C) 2025  Luke Houston
+    R"(
+  FlashBackClient  Copyright (C) 2025  Luke Houston
   This program comes with ABSOLUTELY NO WARRANTY; for details run with
   `--show w'.
 
@@ -37,13 +38,17 @@
   under certain conditions; run with `--show c' for details.)"
 
 #define SHOW_W \
-    R"( FlashBackClient is distributed in the hope that it will be useful,
+    R"(
+
+  FlashBackClient is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.)"
 
 #define SHOW_C \
-    R"( FlashBackClient is free software: you can redistribute it and/or modify
+    R"(
+
+  FlashBackClient is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.

--- a/include/flashbackclient/license_info.h
+++ b/include/flashbackclient/license_info.h
@@ -1,0 +1,52 @@
+/**
+ * @file license_info.h
+ * @author Luke Houston (Romket or RomketBoi) (lukehouston08@gmail.com)
+ * @brief Defines various license notices to display in terminal mode
+ * @version 0.1
+ * @date 2025-04-02
+ *
+ * @see helper.cpp
+ * @sa helper.h
+ *
+ * @copyright Copyright (c) 2025 Luke Houston
+ *
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FlashBackClient is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define NOTICE \
+    R"(  FlashBackClient  Copyright (C) 2025  Luke Houston
+  This program comes with ABSOLUTELY NO WARRANTY; for details run with
+  `--show w'.
+
+  This is free software, and you are welcome to redistribute it
+  under certain conditions; run with `--show c' for details.)"
+
+#define SHOW_W \
+    R"( FlashBackClient is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.)"
+
+#define SHOW_C \
+    R"( FlashBackClient is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  You should have received a copy of the GNU General Public License
+  along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.)"

--- a/include/flashbackclient/listener.h
+++ b/include/flashbackclient/listener.h
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/logging/crashfilesink.h
+++ b/include/flashbackclient/logging/crashfilesink.h
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/logging/dualsink.h
+++ b/include/flashbackclient/logging/dualsink.h
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/logging/logger.h
+++ b/include/flashbackclient/logging/logger.h
@@ -9,18 +9,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/managers/rulemanager.h
+++ b/include/flashbackclient/managers/rulemanager.h
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/managers/settingmanager.h
+++ b/include/flashbackclient/managers/settingmanager.h
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/rule.h
+++ b/include/flashbackclient/rule.h
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/scheduler.h
+++ b/include/flashbackclient/scheduler.h
@@ -14,18 +14,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/service_locator.h
+++ b/include/flashbackclient/service_locator.h
@@ -14,18 +14,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/signal_handler.h
+++ b/include/flashbackclient/signal_handler.h
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/target.h
+++ b/include/flashbackclient/target.h
@@ -19,18 +19,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/include/flashbackclient/trigger.h
+++ b/include/flashbackclient/trigger.h
@@ -14,18 +14,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/condition.h>

--- a/src/configs.cpp
+++ b/src/configs.cpp
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <filesystem>

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -2,7 +2,7 @@
  * @file helper.cpp
  * @author Luke Houston (Romket or RomketBoi) (lukehouston08@gmail.com)
  * @brief Miscellaneous helper functions
- * @version 0.1
+ * @version 0.2
  * @date 2025-04-01
  *
  * @see helper.h
@@ -29,19 +29,23 @@
 #include <flashbackclient/helper.h>
 
 #include <flashbackclient/configs.h>
+#include <flashbackclient/license_info.h>
 #include <flashbackclient/logging/logger.h>
+#include <iostream>
 #include <string>
 
 namespace FlashBackClient
 {
-    bool Helper::ProcessCommandLineArgs(int argc, char** argv)
+    void Helper::DisplayNotice() { std::cout << NOTICE << std::endl; }
+
+    ArgsResult Helper::ProcessCommandLineArgs(int argc, char** argv)
     {
         for (int i = 1; i < argc; ++i)
         {
             if (std::string(argv[i]) == "--generate-configs")
             {
-                FlashBackClient::ConfigManager::GenerateConfigs();
-                return 0;
+                ConfigManager::GenerateConfigs();
+                return ArgsResult::exit;
             }
             else if (std::string(argv[i]) == "--log-level")
             {
@@ -49,47 +53,47 @@ namespace FlashBackClient
                 {
                     if (std::string(argv[i]) == "trace")
                     {
-                        FlashBackClient::Logger::SetLogLevel(0);
+                        Logger::SetLogLevel(0);
                     }
                     else if (std::string(argv[i]) == "debug")
                     {
-                        FlashBackClient::Logger::SetLogLevel(1);
+                        Logger::SetLogLevel(1);
                     }
                     else if (std::string(argv[i]) == "info")
                     {
-                        FlashBackClient::Logger::SetLogLevel(2);
+                        Logger::SetLogLevel(2);
                     }
                     else if (std::string(argv[i]) == "warn")
                     {
-                        FlashBackClient::Logger::SetLogLevel(3);
+                        Logger::SetLogLevel(3);
                     }
                     else if (std::string(argv[i]) == "error")
                     {
-                        FlashBackClient::Logger::SetLogLevel(4);
+                        Logger::SetLogLevel(4);
                     }
                     else if (std::string(argv[i]) == "critical")
                     {
-                        FlashBackClient::Logger::SetLogLevel(5);
+                        Logger::SetLogLevel(5);
                     }
                     else if (std::string(argv[i]) == "off")
                     {
-                        FlashBackClient::Logger::SetLogLevel(6);
+                        Logger::SetLogLevel(6);
                     }
                     else
                     {
-                        FlashBackClient::LOG_WARN(
+                        LOG_WARN(
                             "Unknown log level inputted, defaulting to info");
                     }
                 }
                 else
                 {
-                    FlashBackClient::LOG_WARN("End of arguments reached, "
-                                              "defaulting to info");
+                    LOG_WARN("End of arguments reached, "
+                             "defaulting to info");
                 }
             }
             else if (std::string(argv[i]) == "--always-file-log")
             {
-                FlashBackClient::Logger::AlwaysFileLog();
+                Logger::AlwaysFileLog();
             }
             else if (std::string(argv[i]) == "--backtrace-length")
             {
@@ -97,33 +101,56 @@ namespace FlashBackClient
                 {
                     try
                     {
-                        FlashBackClient::Logger::SetBacktraceLength(
-                            std::stoi(argv[i]));
+                        Logger::SetBacktraceLength(std::stoi(argv[i]));
                     }
                     catch (const std::invalid_argument& e)
                     {
-                        FlashBackClient::LOG_ERROR("Not a valid integer.");
+                        LOG_ERROR("Not a valid integer.");
                     }
                     catch (const std::out_of_range& e)
                     {
-                        FlashBackClient::LOG_ERROR(
-                            "Error: Number out of range.");
+                        LOG_ERROR("Error: Number out of range.");
                     }
                 }
                 else
                 {
-                    FlashBackClient::LOG_WARN(
+                    LOG_WARN(
                         "End of arguments reached, backtrace length unchanged");
+                }
+            }
+            else if (std::string(argv[i]) == "--show")
+            {
+                if (++i < argc)
+                {
+                    if (std::string(argv[i]) == "w")
+                    {
+                        std::cout << SHOW_W << std::endl;
+                    }
+                    else if (std::string(argv[i]) == "c")
+                    {
+                        std::cout << SHOW_C << std::endl;
+                    }
+                    else
+                    {
+                        LOG_ERROR(
+                            "Incorrect usage of --show: unknown option {}",
+                            argv[i]);
+                        return ArgsResult::err;
+                    }
+                }
+                else
+                {
+                    LOG_ERROR("Incorrect usage of --show: no option given");
+                    return ArgsResult::err;
                 }
             }
             else
             {
-                FlashBackClient::LOG_ERROR("Unknown command line option {}",
-                                           argv[i]);
-                return false;
+                LOG_ERROR("Unknown command line option {}", argv[i]);
+                return ArgsResult::err;
             }
         }
 
-        return true;
+        return ArgsResult::cont;
     }
 } // namespace FlashBackClient

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -2,7 +2,7 @@
  * @file helper.cpp
  * @author Luke Houston (Romket or RomketBoi) (lukehouston08@gmail.com)
  * @brief Miscellaneous helper functions
- * @version 0.2
+ * @version 0.3
  * @date 2025-04-01
  *
  * @see helper.h
@@ -125,10 +125,12 @@ namespace FlashBackClient
                     if (std::string(argv[i]) == "w")
                     {
                         std::cout << SHOW_W << std::endl;
+                        return ArgsResult::exit;
                     }
                     else if (std::string(argv[i]) == "c")
                     {
                         std::cout << SHOW_C << std::endl;
+                        return ArgsResult::exit;
                     }
                     else
                     {

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -10,18 +10,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/helper.h>

--- a/src/listener/inotify/inotify_listener.cpp
+++ b/src/listener/inotify/inotify_listener.cpp
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "inotify_listener.h"
 

--- a/src/listener/inotify/inotify_listener.h
+++ b/src/listener/inotify/inotify_listener.h
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/listener/platform_listener.h
+++ b/src/listener/platform_listener.h
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/logging/dualsink.cpp
+++ b/src/logging/dualsink.cpp
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/defs.h>

--- a/src/logging/logger.cpp
+++ b/src/logging/logger.cpp
@@ -12,18 +12,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cstdio>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  * @brief Main entry point for the FlashBackClient program. Registers signal
  * handlers, checks command line arguments, and initializes and runs services
  *
- * @version 0.3
+ * @version 0.5
  * @date 2025-03-28
  *
  * @sa service_locator.h
@@ -49,7 +49,13 @@ int main(int argc, char** argv)
 
     FlashBackClient::ConfigManager::GenerateConfigs();
 
-    if (!FlashBackClient::Helper::ProcessCommandLineArgs(argc, argv)) return 1;
+    FlashBackClient::Helper::DisplayNotice();
+
+    FlashBackClient::ArgsResult result =
+        FlashBackClient::Helper::ProcessCommandLineArgs(argc, argv);
+    if (result == FlashBackClient::ArgsResult::err) return 1;
+    else if (result == FlashBackClient::ArgsResult::exit)
+        return 0;
 
     FlashBackClient::ServiceLocator::Provide<FlashBackClient::ConfigManager>(
         new FlashBackClient::ConfigManager());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/service_locator.h>

--- a/src/managers/rulemanager.cpp
+++ b/src/managers/rulemanager.cpp
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/logging/logger.h>

--- a/src/managers/settingmanager.cpp
+++ b/src/managers/settingmanager.cpp
@@ -11,18 +11,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/managers/settingmanager.h>

--- a/src/rule.cpp
+++ b/src/rule.cpp
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/rule.h>

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -15,18 +15,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/scheduler.h>

--- a/src/signal_handler.cpp
+++ b/src/signal_handler.cpp
@@ -13,18 +13,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/signal_handler.h>

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -9,18 +9,20 @@
  *
  * @copyright Copyright (c) 2025 Luke Houston
  *
- * This program is free software: you can redistribute it and/or modify
+ * This file is part of FlashBackClient
+ *
+ * FlashBackClient is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * FlashBackClient is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <flashbackclient/target.h>


### PR DESCRIPTION
- \+ Fix file license notices to match the GNU General Public License guide
- \+ Add copyright notice when starting the program:
- ```  FlashBackClient  Copyright (C) 2025  Luke Houston
  This program comes with ABSOLUTELY NO WARRANTY; for details run with
  `--show w'.

  This is free software, and you are welcome to redistribute it
  under certain conditions; run with `--show c' for details.```
- \+ Add `--show w` and `--show c` commands

- `--show w`:
- ```  FlashBackClient is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.```

- `--show c`
- ```  FlashBackClient is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.

  You should have received a copy of the GNU General Public License
  along with FlashBackClient.  If not, see <https://www.gnu.org/licenses/>.```